### PR TITLE
Fix company_name parser

### DIFF
--- a/staffspy/linkedin/linkedin.py
+++ b/staffspy/linkedin/linkedin.py
@@ -117,7 +117,7 @@ class LinkedInScraper:
         company_id = company["trackingInfo"]["objectUrn"].split(":")[-1]
 
         try:
-            company_name = re.search(r'/company/([^/]+)', company['url']).group(1)
+            company_name = company["universalName"]
         except:
             pass
 


### PR DESCRIPTION
As I read your code and use it in my project, I'd scan some specialized region like Iranian users and it failed so much times! and find-out that the company_name always equal to universalName(especially in other language like Arabia or Persian. thanks for sharing the code.